### PR TITLE
Capture doc inaccuracy fix (kernel extension -> user space audio server plugin)

### DIFF
--- a/docs/api/desktop-capturer.md
+++ b/docs/api/desktop-capturer.md
@@ -99,6 +99,6 @@ which can detected by [`systemPreferences.getMediaAccessStatus`].
 
 ## Caveats
 
-`navigator.mediaDevices.getUserMedia` does not work on macOS for audio capture due to a fundamental limitation whereby apps that want to access the system's audio require a [signed kernel extension](https://developer.apple.com/library/archive/documentation/Security/Conceptual/System_Integrity_Protection_Guide/KernelExtensions/KernelExtensions.html). Chromium, and by extension Electron, does not provide this.
+`navigator.mediaDevices.getUserMedia` does not work on macOS for audio capture due to a fundamental limitation whereby apps that want to access the system's audio require a [User-Space Audio Server Plugin](https://developer.apple.com/library/archive/samplecode/AudioDriverExamples/Introduction/Intro.html). Chromium, and by extension Electron, does not provide this.
 
-It is possible to circumvent this limitation by capturing system audio with another macOS app like Soundflower and passing it through a virtual audio input device. This virtual device can then be queried with `navigator.mediaDevices.getUserMedia`.
+It is possible to circumvent this limitation by capturing system audio with another macOS app like Soundflower or [BackgroundMusic](https://github.com/kyleneideck/BackgroundMusic) and passing it through a virtual audio input device. This virtual device can then be queried with `navigator.mediaDevices.getUserMedia`.


### PR DESCRIPTION
Kernel extensions for audio drivers have been discouraged for a while in favour of user space audio server plugins which do not need special kernel signing certificates.

#### Description of Change
This PR fixes an inaccuracy in the capturer API doc.

#### Checklist

- [X ] relevant documentation is changed or added
